### PR TITLE
README: chat link to chef community slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Home for discussion about Chef Brigade, and various guides for cookbook authors.
 
-Live discussion happens on [![Slack](http://brigade-slackin.herokuapp.com/badge.svg)](https://brigade-slackin.herokuapp.com/)
+Live discussion happens on [![Chef Community Slack](https://community-slack.chef.io/badge.svg)](https://community-slack.chef.io/) in [#chef_brigade](https://chefcommunity.slack.com/messages/chef_brigade/).
 
 Cookbooks:
 - [`bsdcpio`](https://github.com/chef-brigade/bsdcpio_cookbook)


### PR DESCRIPTION
now that we're in chef community slack, we can remove our slack room.
